### PR TITLE
Migration hotfix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,3 +51,14 @@ jobs:
           script_stop: true
           script: |
             # Move to the correct directory
+            cd "$NFSN_DIR"
+
+            # Install composer dependencies, but don't try to run the script
+            # afterword because it will segfault
+            composer install -o --no-dev --no-scripts
+
+            # Run the postinstall script manually
+            php artisan package:discover
+
+            # Migrate any new migrations
+            php artisan migrate --force

--- a/database/migrations/2020_06_21_015112_create_languages_table.php
+++ b/database/migrations/2020_06_21_015112_create_languages_table.php
@@ -19,7 +19,7 @@ class CreateLanguagesTable extends Migration
             $table->string('iso')->nullable();
             $table->text('alternate_names')->nullable();
             $table->boolean('reconstructed')->default(false);
-            $table->json('position')->nullable();
+            $table->string('position')->nullable();
             $table->text('notes')->nullable();
             $table->integer('order_key')->default(-1);
             $table->string('group_name');


### PR DESCRIPTION
The production environment doesn't allow `json` columns, so the `location` column has been changed to `text`. While we're at it, also fixes the deploy script since it somehow got truncated.